### PR TITLE
Setup DatabaseCleaner strategies and patterns.

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
       tzinfo (~> 1.1)
     arel (7.1.4)
     concurrent-ruby (1.1.5)
+    database_cleaner (1.7.0)
     diff-lcs (1.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -49,6 +50,7 @@ PLATFORMS
 DEPENDENCIES
   bitemporality!
   bundler (~> 1.17)
+  database_cleaner
   rake (~> 10.0)
   rspec (~> 3.0)
   sqlite3 (~> 1.3.13)

--- a/ruby/bitemporality.gemspec
+++ b/ruby/bitemporality.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "sqlite3", '~> 1.3.13'
 end

--- a/ruby/spec/immutable_record_spec.rb
+++ b/ruby/spec/immutable_record_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe Bitemporal::ImmutableRecord do
-  before do
-    make_sqlite_database
+  before(:all) do
     ActiveRecord::Base.connection.execute(
       <<-SQL
-        DROP TABLE IF EXISTS immutable_addresses;
+        DROP TABLE IF EXISTS immutable_addresses
       SQL
     )
     ActiveRecord::Base.connection.execute(
@@ -20,14 +19,6 @@ RSpec.describe Bitemporal::ImmutableRecord do
     ActiveRecord::Base.connection.execute(
       <<-SQL
         DROP TABLE immutable_addresses
-      SQL
-    )
-  end
-
-  after do
-    ActiveRecord::Base.connection.execute(
-      <<-SQL
-        DELETE FROM immutable_addresses
       SQL
     )
   end

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -2,9 +2,25 @@ require 'bundler/setup'
 Bundler.setup
 
 require 'bitemporal'
+require 'database_cleaner'
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    make_sqlite_database
+    DatabaseCleaner.clean_with(:truncation)
+  end
 
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end
 
 def make_sqlite_database

--- a/ruby/spec/versioned_spec.rb
+++ b/ruby/spec/versioned_spec.rb
@@ -2,15 +2,14 @@ require 'spec_helper'
 
 RSpec.describe Bitemporal::Versioned do
   before(:all) do
-    make_sqlite_database
     ActiveRecord::Base.connection.execute(
       <<-SQL
-        DROP TABLE IF EXISTS immutable_addresses;
+        DROP TABLE IF EXISTS versioned_addresses
       SQL
     )
     ActiveRecord::Base.connection.execute(
       <<-SQL
-        CREATE TABLE IF NOT EXISTS immutable_addresses (
+        CREATE TABLE IF NOT EXISTS versioned_addresses (
           uuid string NOT NULL,
           effective_start datetime NOT NULL,
           effective_stop datetime NOT NULL,
@@ -22,22 +21,14 @@ RSpec.describe Bitemporal::Versioned do
   after(:all) do
     ActiveRecord::Base.connection.execute(
       <<-SQL
-        DROP TABLE immutable_addresses
-      SQL
-    )
-  end
-
-  after do
-    ActiveRecord::Base.connection.execute(
-      <<-SQL
-        DELETE FROM immutable_addresses
+        DROP TABLE versioned_addresses
       SQL
     )
   end
 
   let(:klass) do
     Class.new(ActiveRecord::Base) do
-      self.table_name = 'immutable_addresses'
+      self.table_name = 'versioned_addresses'
       include Bitemporal::Versioned
     end
   end


### PR DESCRIPTION
Warning: ActiveRecord caches + creates classes based on table names used
through its DB connection. Therefore, we can't re-use the same table
name for the different test files without jumping through hoops to reset
the column information.